### PR TITLE
bpo-40077: Convert _pickle module to use PyType_FromModuleAndSpec()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2022-01-25-12-31-43.bpo-40077.j-KC3N.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2022-01-25-12-31-43.bpo-40077.j-KC3N.rst
@@ -1,0 +1,1 @@
+Convert :mod:`pickle` to use heap types.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -229,6 +229,9 @@ _Pickle_ClearState(PickleState *st)
     Py_CLEAR(st->partial);
     Py_CLEAR(st->Pickler_Type);
     Py_CLEAR(st->Unpickler_Type);
+    Py_CLEAR(st->Pdata_Type);
+    Py_CLEAR(st->PicklerMemoProxyType);
+    Py_CLEAR(st->UnpicklerMemoProxyType);
 }
 
 /* Initialize the given pickle module state. */
@@ -7912,6 +7915,9 @@ pickle_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(st->partial);
     Py_VISIT(st->Pickler_Type);
     Py_VISIT(st->Unpickler_Type);
+    Py_VISIT(st->Pdata_Type);
+    Py_VISIT(st->PicklerMemoProxyType);
+    Py_VISIT(st->UnpicklerMemoProxyType);
     return 0;
 }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4958,7 +4958,7 @@ static PyObject *
 PicklerMemoProxy_New(PicklerObject *pickler)
 {
     PicklerMemoProxyObject *self;
-    PickleState *state = find_pickle_state_by_type(Py_TYPE(pickler));
+    PickleState *state = get_pickle_state_by_class(Py_TYPE(pickler));
 
     self = PyObject_GC_New(PicklerMemoProxyObject, state->PicklerMemoProxyType);
     if (self == NULL)
@@ -4988,7 +4988,7 @@ Pickler_set_memo(PicklerObject *self, PyObject *obj, void *Py_UNUSED(ignored))
         return -1;
     }
 
-    PickleState *state = find_pickle_state_by_type(Py_TYPE(self));
+    PickleState *state = get_pickle_state_by_class(Py_TYPE(self));
 
     if (Py_IS_TYPE(obj, state->PicklerMemoProxyType)) {
         PicklerObject *pickler =

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4641,6 +4641,8 @@ static struct PyMethodDef Pickler_methods[] = {
 static void
 Pickler_dealloc(PicklerObject *self)
 {
+    PyTypeObject *tp = Py_TYPE(self);
+
     PyObject_GC_UnTrack(self);
 
     Py_XDECREF(self->output_buffer);
@@ -4653,7 +4655,8 @@ Pickler_dealloc(PicklerObject *self)
 
     PyMemoTable_Del(self->memo);
 
-    Py_TYPE(self)->tp_free((PyObject *)self);
+    tp->tp_free((PyObject *)self);
+    Py_DECREF(tp);
 }
 
 static int
@@ -7137,6 +7140,8 @@ static struct PyMethodDef Unpickler_methods[] = {
 static void
 Unpickler_dealloc(UnpicklerObject *self)
 {
+    PyTypeObject *tp = Py_TYPE(self);
+
     PyObject_GC_UnTrack((PyObject *)self);
     Py_XDECREF(self->readline);
     Py_XDECREF(self->readinto);
@@ -7156,7 +7161,8 @@ Unpickler_dealloc(UnpicklerObject *self)
     PyMem_Free(self->encoding);
     PyMem_Free(self->errors);
 
-    Py_TYPE(self)->tp_free((PyObject *)self);
+    tp->tp_free((PyObject *)self);
+    Py_DECREF(tp);
 }
 
 static int


### PR DESCRIPTION
Replace statically allocated types in _pickle module with heap allocated types:
use PyType_FromSpec().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
