### PR TITLE
bpo-45735: Promised that lists can be used for Thread args.

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -485,9 +485,9 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    to ``True`` or ``False``.  If ``None`` (the default), this flag will be
    inherited from the creating process.
 
-   By default, no arguments are passed to *target*, the *args* is set to ``()``.
-   Besides, similar to :class:`threading.Thread`, it is feasible to use a list or
-   tuple as the *args* to pass arguments.
+   By default, no arguments are passed to *target*. The *args* argument,
+   which defaults to ``()``, can be used to specify a list or  tuple of  the arguments
+   to pass to *target*.
 
    If a subclass overrides the constructor, it must make sure it invokes the
    base class constructor (:meth:`Process.__init__`) before doing anything else

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -505,8 +505,8 @@ The :mod:`multiprocessing` package mostly replicates the API of the
       the target argument, if any, with sequential and keyword arguments taken
       from the *args* and *kwargs* arguments, respectively.
 
-      Using list or tuple as the *args* argument which passed to the :class:`Process`
-      could achieve the same effect.
+      Using a list or tuple as the *args* argument passed to :class:`Process`
+      achieves the same effect.
 
       Example::
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -485,7 +485,9 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    to ``True`` or ``False``.  If ``None`` (the default), this flag will be
    inherited from the creating process.
 
-   By default, no arguments are passed to *target*.
+   By default, no arguments are passed to *target*, the *args* is set to ``()``.
+   Besides, similar to :class:`threading.Thread`, it is feasible to use a list or
+   tuple as the *args* to pass arguments.
 
    If a subclass overrides the constructor, it must make sure it invokes the
    base class constructor (:meth:`Process.__init__`) before doing anything else
@@ -502,6 +504,19 @@ The :mod:`multiprocessing` package mostly replicates the API of the
       method invokes the callable object passed to the object's constructor as
       the target argument, if any, with sequential and keyword arguments taken
       from the *args* and *kwargs* arguments, respectively.
+
+      Using list or tuple as the *args* argument which passed to the :class:`Process`
+      could achieve the same effect.
+
+      Example::
+
+         >>> from multiprocessing import Process
+         >>> p = Process(target=print, args=[1])
+         >>> p.run()
+         1
+         >>> p = Process(target=print, args=(1,))
+         >>> p.run()
+         1
 
    .. method:: start()
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -486,7 +486,7 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    inherited from the creating process.
 
    By default, no arguments are passed to *target*. The *args* argument,
-   which defaults to ``()``, can be used to specify a list or  tuple of  the arguments
+   which defaults to ``()``, can be used to specify a list or tuple of the arguments
    to pass to *target*.
 
    If a subclass overrides the constructor, it must make sure it invokes the

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -314,7 +314,7 @@ since it is impossible to detect the termination of alien threads.
    or "Thread-*N* (target)" where "target" is ``target.__name__`` if the
    *target* argument is specified.
 
-   *args* is the argument tuple for the target invocation.  Defaults to ``()``.
+   *args* is a list or tuple of arguments for the target invocation.  Defaults to ``()``.
 
    *kwargs* is a dictionary of keyword arguments for the target invocation.
    Defaults to ``{}``.

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -353,6 +353,19 @@ since it is impossible to detect the termination of alien threads.
       the *target* argument, if any, with positional and keyword arguments taken
       from the *args* and *kwargs* arguments, respectively.
 
+      Using list or tuple as the *args* argument which passed to the :class:`Thread`
+      could achieve the same effect.
+
+      Example::
+
+         >>> from threading import Thread
+         >>> t = Thread(target=print, args=[1])
+         >>> t.run()
+         1
+         >>> t = Thread(target=print, args=(1,))
+         >>> t.run()
+         1
+
    .. method:: join(timeout=None)
 
       Wait until the thread terminates. This blocks the calling thread until

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -268,8 +268,9 @@ class _TestProcess(BaseTestCase):
             [tuple_in_list, lambda arg: self.assertEqual(arg, (1,))]
         ]
         for test_case in test_cases:
-            p = self.Process(target=test_case[1], args=test_case[0])
-            p.start()
+            with self.subTest(test_case=test_case):
+                p = self.Process(target=test_case[1], args=test_case[0])
+                p.start()
 
     def test_daemon_argument(self):
         if self.TYPE == "threads":

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -247,6 +247,30 @@ class _TestProcess(BaseTestCase):
         self.assertEqual(current.ident, os.getpid())
         self.assertEqual(current.exitcode, None)
 
+    def test_args_argument(self):
+        # bpo-45735: Using list or tuple as *args* in constructor could
+        # achieve the same effect.
+        num_list = [1]
+        num_tuple = (1,)
+
+        str_list = ["str"]
+        str_tuple = ("str",)
+
+        list_in_tuple = ([1],)
+        tuple_in_list = [(1,)]
+
+        test_cases = [
+            [num_list, lambda arg: self.assertEqual(arg, 1)],
+            [num_tuple, lambda arg: self.assertEqual(arg, 1)],
+            [str_list, lambda arg: self.assertEqual(arg, "str")],
+            [str_tuple, lambda arg: self.assertEqual(arg, "str")],
+            [list_in_tuple, lambda arg: self.assertEqual(arg, [1])],
+            [tuple_in_list, lambda arg: self.assertEqual(arg, (1,))]
+        ]
+        for test_case in test_cases:
+            p = multiprocessing.Process(target=test_case[1], args=test_case[0])
+            p.start()
+
     def test_daemon_argument(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -268,7 +268,7 @@ class _TestProcess(BaseTestCase):
             [tuple_in_list, lambda arg: self.assertEqual(arg, (1,))]
         ]
         for test_case in test_cases:
-            p = multiprocessing.Process(target=test_case[1], args=test_case[0])
+            p = self.Process(target=test_case[1], args=test_case[0])
             p.start()
 
     def test_daemon_argument(self):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -135,17 +135,18 @@ class ThreadTests(BaseTestCase):
         list_in_tuple = ([1],)
         tuple_in_list = [(1,)]
 
-        test_cases = [
-            [num_list, lambda arg: self.assertEqual(arg, 1)],
-            [num_tuple, lambda arg: self.assertEqual(arg, 1)],
-            [str_list, lambda arg: self.assertEqual(arg, "str")],
-            [str_tuple, lambda arg: self.assertEqual(arg, "str")],
-            [list_in_tuple, lambda arg: self.assertEqual(arg, [1])],
-            [tuple_in_list, lambda arg: self.assertEqual(arg, (1,))]
-        ]
-        for test_case in test_cases:
-            with self.subTest(test_case=test_case):
-                t = threading.Thread(target=test_case[1], args=test_case[0])
+        test_cases = (
+            (num_list, lambda arg: self.assertEqual(arg, 1)),
+            (num_tuple, lambda arg: self.assertEqual(arg, 1)),
+            (str_list, lambda arg: self.assertEqual(arg, "str")),
+            (str_tuple, lambda arg: self.assertEqual(arg, "str")),
+            (list_in_tuple, lambda arg: self.assertEqual(arg, [1])),
+            (tuple_in_list, lambda arg: self.assertEqual(arg, (1,)))
+        )
+
+        for args, target in test_cases:
+            with self.subTest(target=target, args=args):
+                t = threading.Thread(target=target, args=args)
                 t.start()
 
     @cpython_only

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -124,7 +124,7 @@ class ThreadTests(BaseTestCase):
             self.assertEqual(thread.name, "Thread-5 (func)")
 
     def test_args_argument(self):
-        # Using list or tuple as *args* in constructor could
+        # bpo-45735: Using list or tuple as *args* in constructor could
         # achieve the same effect.
         num_list = [1]
         num_tuple = (1,)

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -123,37 +123,25 @@ class ThreadTests(BaseTestCase):
             thread = threading.Thread(target=func)
             self.assertEqual(thread.name, "Thread-5 (func)")
 
-    def test_run_with_diff_args(self):
+    def test_args_argument(self):
         # Using list or tuple as *args* in constructor could
         # achieve the same effect.
         num_list = [1]
         num_tuple = (1,)
 
-        def func_with_num_args(arg):
-            self.assertEqual(arg, 1)
-
         str_list = ["str"]
         str_tuple = ("str",)
-
-        def func_with_str_args(arg):
-            self.assertEqual(arg, "str")
 
         list_in_tuple = ([1],)
         tuple_in_list = [(1,)]
 
-        def func_with_list_args(arg):
-            self.assertEqual(arg, [1])
-
-        def func_with_tuple_args(arg):
-            self.assertEqual(arg, (1,))
-
         test_cases = [
-            [num_list, func_with_num_args],
-            [num_tuple, func_with_num_args],
-            [str_list, func_with_str_args],
-            [str_tuple, func_with_str_args],
-            [list_in_tuple, func_with_list_args],
-            [tuple_in_list, func_with_tuple_args]
+            [num_list, lambda arg: self.assertEqual(arg, 1)],
+            [num_tuple, lambda arg: self.assertEqual(arg, 1)],
+            [str_list, lambda arg: self.assertEqual(arg, "str")],
+            [str_tuple, lambda arg: self.assertEqual(arg, "str")],
+            [list_in_tuple, lambda arg: self.assertEqual(arg, [1])],
+            [tuple_in_list, lambda arg: self.assertEqual(arg, (1,))]
         ]
         for test_case in test_cases:
             t = threading.Thread(target=test_case[1], args=test_case[0])

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -123,6 +123,30 @@ class ThreadTests(BaseTestCase):
             thread = threading.Thread(target=func)
             self.assertEqual(thread.name, "Thread-5 (func)")
 
+    def test_run_with_list_args(self):
+        """
+        Using list or tuple as *args* in constructor could achieve the same effect.
+        """
+        num_list = [1, 2]
+
+        def func_with_num_args(arg1, arg2):
+            self.assertEqual(arg1, num_list[0])
+            self.assertEqual(arg2, num_list[1])
+
+        str_list = ["str1", "str2"]
+
+        def func_with_str_args(arg1, arg2):
+            self.assertEqual(arg1, str_list[0])
+            self.assertEqual(arg2, str_list[1])
+
+        test_suits = [
+            [num_list, func_with_num_args],
+            [str_list, func_with_str_args],
+        ]
+        for test_case in test_suits:
+            t = threading.Thread(target=test_case[1], args=test_case[0])
+            t.start()
+
     @cpython_only
     def test_disallow_instantiation(self):
         # Ensure that the type disallows instantiation (bpo-43916)

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -144,8 +144,9 @@ class ThreadTests(BaseTestCase):
             [tuple_in_list, lambda arg: self.assertEqual(arg, (1,))]
         ]
         for test_case in test_cases:
-            t = threading.Thread(target=test_case[1], args=test_case[0])
-            t.start()
+            with self.subTest(test_case=test_case):
+                t = threading.Thread(target=test_case[1], args=test_case[0])
+                t.start()
 
     @cpython_only
     def test_disallow_instantiation(self):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -123,27 +123,39 @@ class ThreadTests(BaseTestCase):
             thread = threading.Thread(target=func)
             self.assertEqual(thread.name, "Thread-5 (func)")
 
-    def test_run_with_list_args(self):
-        """
-        Using list or tuple as *args* in constructor could achieve the same effect.
-        """
-        num_list = [1, 2]
+    def test_run_with_diff_args(self):
+        # Using list or tuple as *args* in constructor could
+        # achieve the same effect.
+        num_list = [1]
+        num_tuple = (1,)
 
-        def func_with_num_args(arg1, arg2):
-            self.assertEqual(arg1, num_list[0])
-            self.assertEqual(arg2, num_list[1])
+        def func_with_num_args(arg):
+            self.assertEqual(arg, 1)
 
-        str_list = ["str1", "str2"]
+        str_list = ["str"]
+        str_tuple = ("str",)
 
-        def func_with_str_args(arg1, arg2):
-            self.assertEqual(arg1, str_list[0])
-            self.assertEqual(arg2, str_list[1])
+        def func_with_str_args(arg):
+            self.assertEqual(arg, "str")
 
-        test_suits = [
+        list_in_tuple = ([1],)
+        tuple_in_list = [(1,)]
+
+        def func_with_list_args(arg):
+            self.assertEqual(arg, [1])
+
+        def func_with_tuple_args(arg):
+            self.assertEqual(arg, (1,))
+
+        test_cases = [
             [num_list, func_with_num_args],
+            [num_tuple, func_with_num_args],
             [str_list, func_with_str_args],
+            [str_tuple, func_with_str_args],
+            [list_in_tuple, func_with_list_args],
+            [tuple_in_list, func_with_tuple_args]
         ]
-        for test_case in test_suits:
+        for test_case in test_cases:
             t = threading.Thread(target=test_case[1], args=test_case[0])
             t.start()
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -861,14 +861,6 @@ class Thread:
         the base class constructor (Thread.__init__()) before doing anything
         else to the thread.
 
-        Example of using this constructor with a list or tuple *args*:
-
-            >>> t = Thread(target=print, args=[1])
-            >>> t.run()
-            1
-            >>> t = Thread(target=print, args=(1,))
-            >>> t.run()
-            1
         """
         assert group is None, "group argument must be None for now"
         if kwargs is None:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -864,16 +864,12 @@ class Thread:
         Example to use list or tuple as *args* in constructor:
 
             >>> from threading import Thread
-            >>> def func_print(arg1, arg2):
-            ...     print(arg1, arg2)
-            >>> Thread(target=func_print, args=[1, 2]).run()
-            1 2
-            >>> Thread(target=func_print, args=["str1", "str2"]).run()
-            str1 str2
-            >>> Thread(target=func_print, args=(1, 2,)).run()
-            1 2
-            >>> Thread(target=func_print, args=("str1", "str2",)).run()
-            str1 str2
+            >>> t = Thread(target=print, args=[1])
+            >>> t.run()
+            1
+            >>> t = Thread(target=print, args=(1,))
+            >>> t.run()
+            1
         """
         assert group is None, "group argument must be None for now"
         if kwargs is None:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -852,7 +852,7 @@ class Thread:
         *name* is the thread name. By default, a unique name is constructed of
         the form "Thread-N" where N is a small decimal number.
 
-        *args* is the argument tuple for the target invocation. Defaults to ().
+        *args* is a list or tuple of arguments for the target invocation. Defaults to ().
 
         *kwargs* is a dictionary of keyword arguments for the target
         invocation. Defaults to {}.
@@ -861,6 +861,19 @@ class Thread:
         the base class constructor (Thread.__init__()) before doing anything
         else to the thread.
 
+        Example to use list or tuple as *args* in constructor:
+
+            >>> from threading import Thread
+            >>> def func_print(arg1, arg2):
+            ...     print(arg1, arg2)
+            >>> Thread(target=func_print, args=[1, 2]).run()
+            1 2
+            >>> Thread(target=func_print, args=["str1", "str2"]).run()
+            str1 str2
+            >>> Thread(target=func_print, args=(1, 2,)).run()
+            1 2
+            >>> Thread(target=func_print, args=("str1", "str2",)).run()
+            str1 str2
         """
         assert group is None, "group argument must be None for now"
         if kwargs is None:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -861,9 +861,8 @@ class Thread:
         the base class constructor (Thread.__init__()) before doing anything
         else to the thread.
 
-        Example to use list or tuple as *args* in constructor:
+        Example of using this constructor with a list or tuple *args*:
 
-            >>> from threading import Thread
             >>> t = Thread(target=print, args=[1])
             >>> t.run()
             1

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1999,6 +1999,7 @@ Yuxiao Zeng
 Uwe Zessin
 Cheng Zhang
 George Zhang
+Charlie Zhao
 Kai Zhu
 Tarek Ziadé
 Jelle Zijlstra


### PR DESCRIPTION
Change description of class `threading.Thread` to explain the validity of list *args*.

Add doc example and test cases for `threading.Thread`.

https://bugs.python.org/issue45735

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
